### PR TITLE
Dwa testy i kilka korekt

### DIFF
--- a/test_forward_1.sh
+++ b/test_forward_1.sh
@@ -66,14 +66,14 @@ do
 	
 	if [ $SRC_FILE_NAME != "phone_forward_example.c" ]
 	then
-		SRC_FILES+=$SRC_FILE
+		SRC_FILES+="${SRC_FILE} "
 	fi
 done
 
 for TEST in $TEST_DIR/*.c
 do
 	echo -e "${BOLD}========= Running test ${TEST} =========${NORMAL}\n"
-	$CC $CFLAGS -o ${TEST%.c}.o $TEST $SRC_FILES >/dev/null 2>&1
+	$CC $CFLAGS -o ${TEST%.c}.o $TEST $SRC_FILES >/dev/null 
 	
 	if [ $? != 0 ]
 	then

--- a/testy_forward_1/pggp_test_memory_failure.c
+++ b/testy_forward_1/pggp_test_memory_failure.c
@@ -1,0 +1,191 @@
+#include <stdio.h>
+
+#include "phone_forward.h"
+
+#include <stdbool.h>
+#include <sys/resource.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+void add_till_memory_ends(PhoneForward * pf);
+void test_memory_allocation_failure(bool testReverse);
+
+int main(int argc, char **argv) {
+    return 0;
+    #define MEM_LIMIT 320000000 // 320 Mb
+    // Ustawiamy limit pamięci
+    // Jeśli Valgrind odpala errory, to warto spróbować zwiększyć ten limit
+    struct rlimit rl = {MEM_LIMIT, MEM_LIMIT};
+    setrlimit(RLIMIT_AS, &rl);
+
+    printf("Test sprawdza co się stanie, gdy będzie brakować pamięci. \n\n");
+    printf("Test korzysta z nietrywialnej biblioteki(<sys/resource.h>) i polecam uruchomić na studentsie.\n");
+    printf("Na innych maszynach może się wykonywać baaardzo długo, bo może nie działać ograniczanie pamięci.\n");
+    printf("Jeśli test jest poza students, to można usunąć test.\n\n");
+
+
+    printf("Nie należy przejmować się czasem, głębszy opis w mainie kodu testu.\n\n");
+
+
+
+    bool testReverse = true;
+
+    if (argc != 0) {
+        if (strcmp(argv[0], "s"))
+            testReverse = false;
+    }
+
+    //      UWAGA, TEN TEST NIE JEST WYDAJNOŚCIOWY!!!!!!!!!
+    //      NIE PRZEJMUJCIE SIĘ CZASAMI
+
+    //      UWAGA 2,  TEST DZIAŁA NA OGRANICZONEJ PAMIĘCI
+    //      VALGRIND CZASEM NA NIM WARIUJE!!!!!
+
+
+    /*
+     *                      TEST MEMORY FAILURE
+     *
+     *  Test ma na celu sprawdzenie błędów obsługi pamięci.
+     *  UWAGA!!!! Nie należy przejmować się czasem na tym teście. Być może
+     *  dla programu bardzo optymalnego pamięciowo, trzeba będzie bardzo dużo
+     *  operacji, aby skończył się RAM. Jeśli ktoś ma wolniejszą implementację,
+     *  to zachęcamy do obniżenia liczby NUMBER_OF_TEST_OPERATIONS.
+     *
+     *  Na początku wrzuca bardzo dużo rzeczy do programu,
+     *  aż nie skończy się pamięć.
+     *  Przez skończenie się pamięci
+     *  rozumiemy sytuacje, kiedy funkcja add zaczyna zwracać wartość false.
+     *
+     *  Następnie program zaczyna wykonywać losowe operacje, tak, aby
+     *  często następowała sytuacja braku pamięci.
+     *
+     *  Program wykrywa dwa błędy:
+     *  -> brak obsługi sytuacji, gdy malloc zwraca NULL -> wtedy najpewniej
+     *     nastąpi naruszenie ochrony pamięci,
+     *  -> rozczłonkowywanie się drzewa, jeśli mamy drzewo -> wtedy potrzeba
+     *     uruchomić test pod Valgrindem i on powinien pokazać memory_leak.
+     */
+
+    #define NUMBER_OF_TEST_OPERATIONS 1000
+
+   test_memory_allocation_failure(testReverse);
+}
+
+void add_till_memory_ends(PhoneForward * pf) {
+    int i = 0;
+    while(true) {
+        // Wrzucamy do struktury przekierowanie dwóch 5-30 znakowych numerów
+        char str1[31];
+        int len1 = 5 + rand() % 10;
+        char str2[31];
+        int len2 = 5 + rand() % 10;
+
+        // Generujemy te numery...
+        for (int j = 0; j < len1; ++j) {
+            str1[j] = rand() % 3 + '0';
+        }
+        str1[len1] = '\0';
+
+        for (int j = 0; j < len2; ++j) {
+            str2[j] = rand() % 3 + '0';
+        }
+        str2[len2] = '\0';
+
+        // i próbujemy wrzucić do struktury
+        if(!phfwdAdd(pf, str1, str2)) {
+            // jeśli się nie da, to znaczy, że wypełniliśmy całą pamięć
+            break;
+        }
+        i++;
+
+        if(i % 10000 == 0) {
+            //printf("Wykonano %d addów.\n", i);
+        }
+    }
+}
+
+void test_memory_allocation_failure(bool testReverse){
+
+    PhoneForward * pf = phfwdNew();
+
+    // Pętla, która ma doprowadzić do przepełnienia pamięci
+    add_till_memory_ends(pf);
+
+
+    /*
+     * Teraz program zacznie wykonywanie losowych operacji
+     */
+    int operation;
+    for (int op_ind = 0; op_ind < NUMBER_OF_TEST_OPERATIONS; ++op_ind) {
+        operation = rand() % 100;
+        /*
+         * 0 - 40 => add
+         * 40 - 60 => remove
+         * 60 - 80 => get
+         * 80 - 100 => reverse, jeśli flaga jest włączona
+         */
+
+        /*
+         * Najpierw generuję dwie liczby losowe
+         * składające się z cyfr 0-2 i mające od 5 do 20 znaków.
+         *
+         */
+        char str1[31];
+        int len1 = 5 + rand() % 10;
+        char str2[31];
+        int len2 = 5 + rand() % 10;
+        for (int j = 0; j < len1; ++j) {
+            str1[j] = rand() % 3 + '0';
+        }
+        str1[len1] = '\0';
+
+        for (int j = 0; j < len2; ++j) {
+            str2[j] = rand() % 3 + '0';
+        }
+        str2[len2] = '\0';
+
+        if(operation < 40) {
+            // add
+            add_till_memory_ends(pf);
+        }
+
+        if(operation >= 40 && operation < 60) {
+            // remove
+            phfwdRemove(pf, str1);
+        }
+
+        if(operation >= 60 && operation < 80) {
+            // get
+            PhoneNumbers * pn = phfwdGet(pf, str1);
+            if(pn != NULL) {
+                int t = 0;
+                while (phnumGet(pn, t) != NULL) {
+                    t++;
+                }
+                phnumDelete(pn);
+            }
+        }
+
+        if(operation >= 80) {
+            // reverse
+            if(testReverse) {
+                PhoneNumbers * pn = phfwdReverse(pf, str1);
+                if(pn != NULL) {
+                    int t = 0;
+                    while (phnumGet(pn, t) != NULL) {
+                        t++;
+                    }
+                }
+                phnumDelete(pn);
+            }
+        }
+
+
+        phfwdAdd(pf, str1, str2);
+    }
+
+    // Usuwamy drzewo, kończąc nasz program
+    phfwdDelete(pf);
+}
+

--- a/testy_forward_1/pggp_test_memory_failure.c
+++ b/testy_forward_1/pggp_test_memory_failure.c
@@ -12,7 +12,6 @@ void add_till_memory_ends(PhoneForward * pf);
 void test_memory_allocation_failure(bool testReverse);
 
 int main(int argc, char **argv) {
-    return 0;
     #define MEM_LIMIT 320000000 // 320 Mb
     // Ustawiamy limit pamięci
     // Jeśli Valgrind odpala errory, to warto spróbować zwiększyć ten limit

--- a/testy_forward_1/pggp_test_stack_overflow.c
+++ b/testy_forward_1/pggp_test_stack_overflow.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+
+#include "phone_forward.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+int main(int argc, char **argv) {
+    bool testReverse = true;
+
+    if (argc != 0) {
+        if (strcmp(argv[0], "s"))
+            testReverse = false;
+    }
+
+    //      UWAGA, TEN TEST NIE JEST WYDAJNOŚCIOWY!!!!!!!!!
+    //      NIE PRZEJMUJCIE SIĘ CZASAMI
+
+    /*
+     *                      TEST STACK OVERFLOW
+     *
+     * Jeśli zrobisz długiego DFSa - np. na drzewie o głębokości 10^7, to stos
+     * zajmie więcej niż 16MB. Przekroczenie stosu to jest błąd to którego
+     * nie można dopuścić - trzeba albo iterować się po drzewie whilami,
+     * albo nie wiem. Nie można w ogóle robić baardzo długich rekurencji.
+     */
+
+    #define TREE_DEPTH 20000000 // 20 MB - więcej niż stos
+    // Próbujemy zrobić 2 bardzo długie napisy
+    char *a = calloc(TREE_DEPTH + 1, sizeof(char));
+    char *b = calloc(TREE_DEPTH + 1, sizeof(char));
+    if(a == NULL || b == NULL) {
+        printf("Błąd testu. Być może twoja wina, być może jest za mało pamięci.\n");
+        assert(false);
+    }
+    for (int i = 0; i < TREE_DEPTH; ++i) {
+        a[i] = '1';
+        b[i] = '2';
+    }
+    a[TREE_DEPTH] = '\0';
+    b[TREE_DEPTH] = '\0';
+
+    PhoneForward * pf = phfwdNew();
+
+    phfwdAdd(pf, a, b);
+
+    PhoneNumbers * pn = phfwdGet(pf, a);
+
+    assert(pn != NULL);
+    assert(strcmp(phnumGet(pn, 0), b) == 0);
+    assert(phnumGet(pn, 1) == NULL);
+    phnumDelete(pn);
+
+    // Usunięcie drzewa nie może być robione klasycznym DFSem.
+    phfwdDelete(pf);
+    free(a);
+    free(b);
+
+}

--- a/testy_forward_1/phone_forward_example.c
+++ b/testy_forward_1/phone_forward_example.c
@@ -12,7 +12,7 @@
 int main(int argc, char **argv) {
 	bool testReverse = true;
 
-	if (argc != 0) {
+	if (argc != 1) {
 		if (strcmp(argv[0], "s"))
 			testReverse = false;
 	}


### PR DESCRIPTION
Dałem dwa testy - jeden na to, co się dzieje, gdy pamięć się kończy. Drugi na stack_overflow.

Poza tym poprawiłem jakieś 2 bugi – teraz zawsze wywoływało się z pomijaniem reverse – w kodzie phone_cośtam_example było "argc==0", co nigdy nie jest prawdą – zawsze jednym argumentem jest nazwa pliku. Zmieniłem na "argc==1".

Był też mały problem z kompilacją, jak się miało więcej niż 1 plik – nie było spacji między nazwami.

Usunąłem przekierowanie erroru przy kompilacji do dev/null -> wydaje mi się, że warto, aby było wiadomo, czemu taki error powstał.

Przepraszam, za załamanie dwóch zasad:

1. W jednym teście zaimportowałem fancy bibliotekę. Jest na students. Nie wiem jak inaczej stestować ograniczenie pamięciowe w skończonym czasie bez tego, jestem otwarty na propozycje. Jest stosowny komentarz, jak się test uruchamia, żeby ludzie mogli pominąć.

2. Nie mogę dać tych testów do 1 pliku, bo w jednym nakładam mały limit na pamięć – jest to konieczne ze względu czasu wykonania. Zaś w drugim potrzeba dużej pamięci. Nie da się tego łatwo zrobić, a potencjalny zysk niewielki, więc mam nadzieję, że się nikt nie obrazi.

Życzę Wspaniałego Śniadania jutro,
Paweł