### PR TITLE
Poprawiono skrypt testujący

### DIFF
--- a/test_forward.sh
+++ b/test_forward.sh
@@ -2,8 +2,7 @@
 
 CC="gcc"
 CFLAGS="-std=c17 -Wall -Wextra -Wno-implicit-fallthrough -g"
-CFALGS_WRAP="-Wl,--wrap=malloc -Wl,--wrap=calloc -Wl,--wrap=realloc -Wl,
-	--wrap=reallocarray -Wl,--wrap=free -Wl,--wrap=strdup -Wl,--wrap=strndup"
+CFALGS_WRAP="-Wl,--wrap=malloc -Wl,--wrap=calloc -Wl,--wrap=realloc -Wl,--wrap=reallocarray -Wl,--wrap=free -Wl,--wrap=strdup -Wl,--wrap=strndup"
 VALGRIND_FLAGS="--leak-check=full --show-leak-kinds=all
 	--errors-for-leak-kinds=all --quiet"
 TEST_DIR="testy_forward"
@@ -40,7 +39,7 @@ test_cmake() {
   # Test CMake Release
   mkdir tmp_cmake_$1_forward_test
   cd tmp_cmake_$1_forward_test || exit
-  cmake -D CMAKE_BUILD_TYPE=$1 ../$SRC_DIR/..  > /dev/null
+  cmake -D CMAKE_BUILD_TYPE=$1 $SRC_DIR/..  > /dev/null
   make > /dev/null
 
   printf "[OK] TEST CMAKE $1\n"
@@ -58,7 +57,7 @@ test_doc() {
   # Test CMake Release
   mkdir tmp_doc_forward_test
   cd tmp_doc_forward_test || exit
-  cmake  ../$SRC_DIR/..  > /dev/null
+  cmake  $SRC_DIR/..  > /dev/null
   make > /dev/null
   make doc 2> temp_message 1> /dev/null
 
@@ -164,7 +163,7 @@ then
 	echo -e "\n${BOLD}========= Running instrumented =========${NORMAL}\n"
 	echo -n "Compiling... "
 
-	$CC $CFLAGS -o $INSTR_OUT $INSTR_IN $SRC_FILES >/dev/null
+	$CC $CFALGS_WRAP -o $INSTR_OUT $INSTR_IN $SRC_FILES >/dev/null
   [ "$?" -ne 0 ] && printf "${C_RED}Compilation error${C_DEFAULT}\n" && exit 1
 	
 	echo -e "done"

--- a/testy_forward/adjusted_part1_tests.c
+++ b/testy_forward/adjusted_part1_tests.c
@@ -666,6 +666,18 @@ static unsigned alloc_fail_test(void) {
     return visited;
   }
 
+  if (phfwdAdd(pf, "300", "4")) {
+    visited |= 010;
+  }
+  else if (phfwdAdd(pf, "300", "4")) {
+    visited |= 020;
+  }
+  else {
+    visited |= 040;
+    phfwdDelete(pf);
+    return visited;
+  }
+
   if ((pn = phfwdGet(pf, "5791")) != NULL) {
     visited |= 0100;
   }
@@ -690,6 +702,16 @@ static unsigned alloc_fail_test(void) {
     visited |= 04000;
     phfwdDelete(pf);
     return visited;
+  }
+
+  // Obecne przekierowania: 300 -> 4, 579 -> 4.
+  if(strcmp(phnumGet(pn, 0), "300") != 0
+    || strcmp(phnumGet(pn, 1), "4") != 0
+    || strcmp(phnumGet(pn, 2), "579") != 0){
+      printf("Funkcja zwraca niepoprawny PhoneNumbers.\n");
+      visited |= 04000;
+  } else {
+      visited |= 01000;
   }
 
   phnumDelete(pn);


### PR DESCRIPTION
Zamieniłem flagi CFLAGS na CFLAGS_WRAP w sekcji instrumented. Powinieneś Karol sprawdzać, czy ten test alloc_fail działa na kodzie, który nie powinien działać:).
Jeszcze zrobiłem poprawki przy cześć cmake_test oraz lekkie zmiany w pliku adjusted_part1_tests.c.